### PR TITLE
Refactor vertx and servlet sessions into subclasses

### DIFF
--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/httframeworkhandler/CruiseControlHttpSession.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/httframeworkhandler/CruiseControlHttpSession.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.cruisecontrol.httframeworkhandler;
+
+public interface CruiseControlHttpSession {
+
+    void invalidateSession();
+
+    long getLastAccessed();
+
+    String getSessionId();
+}

--- a/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/httframeworkhandler/HttpFrameworkHandler.java
+++ b/cruise-control-core/src/main/java/com/linkedin/cruisecontrol/httframeworkhandler/HttpFrameworkHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
  */
 package com.linkedin.cruisecontrol.httframeworkhandler;
 
@@ -37,13 +37,7 @@ public interface HttpFrameworkHandler<T> {
                                      String responseMessage,
                                      T config) throws IOException;
 
-    void invalidateSession();
-
-    long getLastAccessed();
-
-    Object getSession();
-
-    String getSessionId();
+    CruiseControlHttpSession getSession();
 
     String getRequestURI();
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/httpframeworkhandler/ServletHttpFrameworkHandler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/httpframeworkhandler/ServletHttpFrameworkHandler.java
@@ -5,9 +5,11 @@
 package com.linkedin.kafka.cruisecontrol.httpframeworkhandler;
 
 import com.google.gson.Gson;
+import com.linkedin.cruisecontrol.httframeworkhandler.CruiseControlHttpSession;
 import com.linkedin.cruisecontrol.httframeworkhandler.HttpFrameworkHandler;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
+import com.linkedin.kafka.cruisecontrol.servlet.ServletSession;
 import com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
@@ -39,10 +41,12 @@ public class ServletHttpFrameworkHandler implements HttpFrameworkHandler<KafkaCr
 
     protected HttpServletRequest _request;
     protected HttpServletResponse _response;
+    private final ServletSession _servletSession;
 
     public ServletHttpFrameworkHandler(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
         _request = httpServletRequest;
         _response = httpServletResponse;
+        _servletSession = new ServletSession(_request.getSession());
     }
 
     private MultiMap getServletHeaders(HttpServletRequest request) {
@@ -136,23 +140,8 @@ public class ServletHttpFrameworkHandler implements HttpFrameworkHandler<KafkaCr
     }
 
     @Override
-    public void invalidateSession() {
-        _request.getSession().invalidate();
-    }
-
-    @Override
-    public long getLastAccessed() {
-        return _request.getSession().getLastAccessedTime();
-    }
-
-    @Override
-    public Object getSession() {
-        return _request.getSession();
-    }
-
-    @Override
-    public String getSessionId() {
-        return _request.getSession().getId();
+    public CruiseControlHttpSession getSession() {
+        return _servletSession;
     }
 
     @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/httpframeworkhandler/VertxHttpFrameworkHandler.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/httpframeworkhandler/VertxHttpFrameworkHandler.java
@@ -5,10 +5,12 @@
 package com.linkedin.kafka.cruisecontrol.httpframeworkhandler;
 
 import com.google.gson.Gson;
+import com.linkedin.cruisecontrol.httframeworkhandler.CruiseControlHttpSession;
 import com.linkedin.cruisecontrol.httframeworkhandler.HttpFrameworkHandler;
 import com.linkedin.kafka.cruisecontrol.KafkaCruiseControl;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
 import com.linkedin.kafka.cruisecontrol.servlet.response.ResponseUtils;
+import com.linkedin.kafka.cruisecontrol.vertx.VertxSession;
 import io.vertx.core.MultiMap;
 import io.vertx.ext.web.RoutingContext;
 import java.io.IOException;
@@ -35,9 +37,13 @@ public class VertxHttpFrameworkHandler implements HttpFrameworkHandler<KafkaCrui
     };
 
     protected RoutingContext _context;
+
+    private final CruiseControlHttpSession _session;
+
     public VertxHttpFrameworkHandler(RoutingContext context) {
         super();
         _context = context;
+        _session = new VertxSession(context.session());
     }
 
     @Override
@@ -109,23 +115,8 @@ public class VertxHttpFrameworkHandler implements HttpFrameworkHandler<KafkaCrui
     }
 
     @Override
-    public void invalidateSession() {
-        _context.session().destroy();
-    }
-
-    @Override
-    public long getLastAccessed() {
-        return _context.session().lastAccessed();
-    }
-
-    @Override
-    public Object getSession() {
-        return _context.session();
-    }
-
-    @Override
-    public String getSessionId() {
-        return _context.session().id();
+    public CruiseControlHttpSession getSession() {
+        return _session;
     }
 
     @Override

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/ServletSession.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/ServletSession.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.servlet;
+
+import com.linkedin.cruisecontrol.httframeworkhandler.CruiseControlHttpSession;
+import javax.servlet.http.HttpSession;
+import java.util.Objects;
+
+public class ServletSession implements CruiseControlHttpSession {
+
+    private final HttpSession _httpSession;
+
+    public ServletSession(HttpSession httpSession) {
+        _httpSession = httpSession;
+    }
+
+    @Override
+    public void invalidateSession() {
+        _httpSession.invalidate();
+    }
+
+    @Override
+    public long getLastAccessed() {
+        return _httpSession.getLastAccessedTime();
+    }
+
+    @Override
+    public String getSessionId() {
+        return _httpSession.getId();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ServletSession that = (ServletSession) o;
+        return _httpSession.equals(that._httpSession);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_httpSession);
+    }
+}

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManager.java
@@ -12,6 +12,7 @@ import com.linkedin.cruisecontrol.servlet.EndpointType;
 import com.linkedin.cruisecontrol.httframeworkhandler.HttpFrameworkHandler;
 import com.linkedin.kafka.cruisecontrol.config.constants.UserTaskManagerConfig;
 import com.linkedin.kafka.cruisecontrol.config.constants.WebServerConfig;
+import com.linkedin.cruisecontrol.httframeworkhandler.CruiseControlHttpSession;
 import com.linkedin.kafka.cruisecontrol.servlet.handler.async.runnable.OperationFuture;
 import com.linkedin.kafka.cruisecontrol.common.KafkaCruiseControlThreadFactory;
 import com.linkedin.kafka.cruisecontrol.config.KafkaCruiseControlConfig;
@@ -563,23 +564,23 @@ public class UserTaskManager implements Closeable {
   }
 
   public static class SessionKey {
-    private final HttpFrameworkHandler _handler;
+    private final CruiseControlHttpSession _session;
     private final String _requestUrl;
     private final Map<String, Set<String>> _queryParams;
 
     SessionKey(HttpFrameworkHandler<KafkaCruiseControlConfig> handler) {
-      _handler = handler;
+      _session = handler.getSession();
       _requestUrl = httpServletRequestToString(handler);
       _queryParams = new HashMap<>();
       handler.getParameterMap().forEach((k, v) -> _queryParams.put(k, new HashSet<>(Arrays.asList(v))));
     }
 
     protected void invalidateSession() {
-      _handler.invalidateSession();
+      _session.invalidateSession();
     }
 
     protected long getLastAccessed() {
-      return _handler.getLastAccessed();
+      return _session.getLastAccessed();
     }
 
     @Override
@@ -591,28 +592,24 @@ public class UserTaskManager implements Closeable {
         return false;
       }
       SessionKey that = (SessionKey) o;
-      return Objects.equals(_handler, that._handler)
+      return Objects.equals(_session, that._session)
              && Objects.equals(_requestUrl, that._requestUrl)
              && Objects.equals(_queryParams, that._queryParams);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(_handler, _requestUrl, _queryParams);
+      return Objects.hash(_session, _requestUrl, _queryParams);
     }
 
     @Override
     public String toString() {
-      return String.format("SessionKey{_handler=%s,_requestUrl=%s,_queryParams=%s}", _handler, _requestUrl,
+      return String.format("SessionKey{_handler=%s,_requestUrl=%s,_queryParams=%s}", _session, _requestUrl,
                            _queryParams);
     }
 
-    public Object getSession() {
-      return _handler.getSession();
-    }
-
     public Object getSessionId() {
-      return _handler.getSessionId();
+      return _session.getSessionId();
     }
   }
 

--- a/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/vertx/VertxSession.java
+++ b/cruise-control/src/main/java/com/linkedin/kafka/cruisecontrol/vertx/VertxSession.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.
+ */
+
+package com.linkedin.kafka.cruisecontrol.vertx;
+
+import com.linkedin.cruisecontrol.httframeworkhandler.CruiseControlHttpSession;
+import io.vertx.ext.web.Session;
+import java.util.Objects;
+
+public class VertxSession implements CruiseControlHttpSession {
+
+    private final Session _vertxSession;
+
+    public VertxSession(Session vertxSession) {
+        _vertxSession = vertxSession;
+    }
+
+    @Override
+    public void invalidateSession() {
+        _vertxSession.destroy();
+    }
+
+    @Override
+    public long getLastAccessed() {
+        return _vertxSession.lastAccessed();
+    }
+
+    @Override
+    public String getSessionId() {
+        return _vertxSession.id();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VertxSession that = (VertxSession) o;
+        return _vertxSession.equals(that._vertxSession);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_vertxSession);
+    }
+}

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/KafkaCruiseControlServletEndpointTest.java
@@ -26,6 +26,8 @@ import kafka.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.easymock.EasyMock;
 import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.LOAD;
 import static com.linkedin.kafka.cruisecontrol.servlet.CruiseControlEndPoint.PROPOSALS;
@@ -148,6 +150,8 @@ public class KafkaCruiseControlServletEndpointTest {
     }
   }
 
+  @Ignore
+  @Test
   public void testUserTaskParameters() throws Exception {
 
     // Set up all mocked requests,  UserTaskManager, and start mocked objects.
@@ -259,7 +263,7 @@ public class KafkaCruiseControlServletEndpointTest {
                                             Map<String, String []> params, String method) {
     HttpFrameworkHandler request = EasyMock.mock(HttpFrameworkHandler.class);
 
-    EasyMock.expect(request.getSession()).andReturn(session).anyTimes();
+    EasyMock.expect(request.getSession()).andReturn(new ServletSession(session)).anyTimes();
     EasyMock.expect(request.getMethod()).andReturn(method).anyTimes();
     EasyMock.expect(request.getRequestURI()).andReturn(KafkaCruiseControlServletTestUtils.getDefaultWebServerApiUrlPrefix() + resource).anyTimes();
     EasyMock.expect(request.getParameterMap()).andReturn(params).anyTimes();

--- a/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
+++ b/cruise-control/src/test/java/com/linkedin/kafka/cruisecontrol/servlet/UserTaskManagerTest.java
@@ -15,6 +15,7 @@ import org.apache.kafka.common.utils.Time;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Assert;
+import org.junit.Test;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -104,7 +105,7 @@ public class UserTaskManagerTest {
     userTaskManager.close();
   }
 
-  //@Test
+  @Test
   public void testSessionsShareUserTask() throws Exception {
     UUID testUserTaskId = UUID.randomUUID();
 


### PR DESCRIPTION
This PR creates a new CruiseControlHttpSession interface that will be the supertype of both vertx and servlet sessions and exposes their respective methods through a common interface. The respective FrameworkHandler methods are moved to these session classes.